### PR TITLE
refactor: Mejora codigo sql de real-time-reports

### DIFF
--- a/app/Http/Controllers/RealtimeReportController.php
+++ b/app/Http/Controllers/RealtimeReportController.php
@@ -9,17 +9,34 @@ class RealtimeReportController extends Controller
 {
     public function index(Request $request)
     {
-        // Lógica de autenticación y autorización
-        $PHP_AUTH_USER = '6666';
+        $campaignSettings = DB::table('vicidial_campaigns')->select(
+            'campaign_id',
+            'auto_dial_level',
+            'dial_status_a',
+            'dial_status_b',
+            'dial_status_c',
+            'dial_status_d',
+            'dial_status_e',
+            'lead_order',
+            'lead_filter_id',
+            'hopper_level',
+            'dial_method',
+            'adaptive_maximum_level',
+            'adaptive_dropped_percentage',
+            'adaptive_dl_diff_target',
+            'adaptive_intensity',
+            'available_only_ratio_tally',
+            'adaptive_latest_server_time',
+            'local_call_time',
+            'dial_timeout',
+            'dial_statuses'
+        )->get();
 
-        // Consultas a la base de datos
-        $systemSettings = DB::table('system_settings')->select('use_non_latin', 'outbound_autodial_active', 'slave_db_server', 'reports_use_slave_db', 'enable_languages', 'language_method', 'agent_whisper_enabled', 'report_default_format', 'enable_pause_code_limits', 'allow_web_debug')->first();
-
-        $userSettings = DB::table('vicidial_users')->where('user', $PHP_AUTH_USER)->first();
+        dd($campaignSettings);
 
         // Más consultas y lógica aquí...
 
-        return view('admin.realtime_report', compact('systemSettings', 'userSettings'));
+        return view('admin.real-time-reports', compact('campaignSettings'));
     }
 
     public function update(Request $request)

--- a/public/vicidial/AST_timeonVDADallSUMMARY.php
+++ b/public/vicidial/AST_timeonVDADallSUMMARY.php
@@ -328,7 +328,7 @@ $stmt = "select count(*) from vicidial_campaigns where campaign_id='$group' and 
 $rslt=mysql_to_mysqli($stmt, $link);
 	$row=mysqli_fetch_row($rslt);
 	$campaign_allow_inbound = $row[0];
-
+// s
 $stmt="select auto_dial_level,dial_status_a,dial_status_b,dial_status_c,dial_status_d,dial_status_e,lead_order,lead_filter_id,hopper_level,dial_method,adaptive_maximum_level,adaptive_dropped_percentage,adaptive_dl_diff_target,adaptive_intensity,available_only_ratio_tally,adaptive_latest_server_time,local_call_time,dial_timeout,dial_statuses from vicidial_campaigns where campaign_id='" . mysqli_real_escape_string($link, $group) . "';";
 $rslt=mysql_to_mysqli($stmt, $link);
 $row=mysqli_fetch_row($rslt);

--- a/public/vicidial/user_status.php
+++ b/public/vicidial/user_status.php
@@ -309,7 +309,7 @@ $row=mysqli_fetch_row($rslt);
 $full_name = $row[0];
 $user_group = $row[1];
 
-$stmt="SELECT live_agent_id,user,server_ip,conf_exten,extension,status,lead_id,campaign_id,uniqueid,callerid,channel,random_id,last_call_time,last_update_time,last_call_finish,closer_campaigns,call_server_ip,user_level,comments,campaign_weight,calls_today,external_hangup,external_status,external_pause,external_dial,agent_log_id,last_state_change,agent_territories,outbound_autodial,manager_ingroup_set,external_igb_set_user from vicidial_live_agents where user='" . mysqli_real_escape_string($link, $user) . "';";
+$stmt="SELECT conf_exten,extension,status,lead_id,campaign_id,uniqueid,callerid,channel,random_id,last_call_time,last_update_time,last_call_finish,closer_campaigns,call_server_ip,user_level,comments,campaign_weight,calls_today,external_hangup,external_status,external_pause,external_dial,agent_log_id,last_state_change,agent_territories,outbound_autodial,manager_ingroup_set,external_igb_set_user from vicidial_live_agents where user='" . mysqli_real_escape_string($link, $user) . "';";
 $rslt=mysql_to_mysqli($stmt, $link);
 if ($DB) {echo "$stmt\n";}
 $agents_to_print = mysqli_num_rows($rslt);

--- a/resources/views/admin/real-time-reports.blade.php
+++ b/resources/views/admin/real-time-reports.blade.php
@@ -5,11 +5,13 @@
 @section('content')
 
 <main class="ease-soft-in-out xl:ml-68.5 relative h-full max-h-screen rounded-xl transition-all duration-200 mt-2">
-
+{{-- 
     <x-lenguage/>
-    <x-modal-realTime/>
-
-    <div
+    <x-modal-realTime/> --}}
+    @foreach ($campaignSettings as $info)
+        {{$info->campaign}}
+    @endforeach
+    {{-- <div
         class="relative flex flex-wrap items-center justify-between px-0 py-2 mx-6 transition-all shadow-none duration-250 ease-soft-in rounded-2xl lg:flex-nowrap lg:justify-start">
     </div>
     <div class="p-6 bg-white min-h-screen">
@@ -331,7 +333,7 @@
         
 
         
-    </div>
+    </div> --}}
     <div data-dial-init class="fixed end-6 bottom-6 group">
         <div id="speed-dial-menu-default" class="flex flex-col items-center hidden mb-4 space-y-2">
             {{-- <button type="button" data-tooltip-target="tooltip-share" data-tooltip-placement="left"

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\AdminLoginController;
 use App\Http\Controllers\ControlAdmin;
+use App\Http\Controllers\RealtimeReportController;
 use App\Livewire\Admin\Dashboard;
 use App\Livewire\Dashboard as LivewireDashboard;
 use Illuminate\Support\Facades\Route;
@@ -38,7 +39,7 @@ Route::get('/admin/lists/{route}', [ControlAdmin::class, 'index'])->name('List-A
 Route::get('/admin/filter/{route}', [ControlAdmin::class, 'index'])->name('Filter-Admin');
 Route::get('/admin/remote-agents/{route}', [ControlAdmin::class, 'index'])->name('Remote-Agents-Admin');
 
-Route::get('real/time/reports/admin', [ControlAdmin::class, 'showAggentsLogged'])->name('Real-Time-Reports-Admin');
+Route::get('real/time/reports/admin', [RealtimeReportController::class, 'index'])->name('Real-Time-Reports-Admin');
 
 
 Route::get('/locale/{locale}', function ($locale) {

--- a/test.db
+++ b/test.db
@@ -1,0 +1,239 @@
+SELECT 
+    use_auto_hopper,
+    auto_hopper_multi,
+    auto_hopper_level,
+    auto_trim_hopper
+FROM vicidial_campaigns where campaign_id ='VBMOVSD';
+
+
+#CONSULTA TABLA USERS ACTIVOS
+
+SELECT 
+    vicidial_live_agents.extension,
+    vicidial_users.full_name,
+    vicidial_users.user_group,
+	vicidial_live_agents.conf_exten,
+    vicidial_live_agents.status,
+    vicidial_live_agents.campaign_id,
+    vicidial_live_agents.calls_today
+FROM 
+    vicidial_users
+INNER JOIN 
+    vicidial_live_agents
+ON 
+    vicidial_users.user = vicidial_live_agents.user;
+
+
+
+select ,,,,,,,,,adaptive_maximum_level,adaptive_dropped_percentage,adaptive_dl_diff_target,adaptive_intensity,available_only_ratio_tally,adaptive_latest_server_time,local_call_time,dial_timeout,dial_statuses from vicidial_campaigns 
+
+
+
+select adaptive_maximum_level from vicidial_campaigns 
+
+
+
+
+SELECT 
+    //00-campaign_id,
+    //0-auto_dial_level,
+    //1-dial_status_a,
+    //2-dial_status_b,
+    //3-dial_status_c,
+    //4-dial_status_d,
+    //5-dial_status_e,
+    //6-lead_order,
+    //7-lead_filter_id,
+    //8-hopper_level,
+    //9-dial_method,
+    //10-adaptive_maximum_level,
+    //11-adaptive_dropped_percentage,
+    //12-adaptive_dl_diff_target,
+    //13-adaptive_intensity,
+    //14-available_only_ratio_tally,
+    //15-adaptive_latest_server_time,
+    //16-local_call_time,
+    //17-dial_timeout,
+    //18-dial_statuses 
+FROM 
+    vicidial_campaigns
+
+
+SELECT 
+    campaign_id,
+    auto_dial_level,
+    dial_status_a,
+    dial_status_b,
+    dial_status_c,
+    dial_status_d,
+    dial_status_e,
+    lead_order,
+    lead_filter_id,
+    hopper_level,
+    dial_method,
+    adaptive_maximum_level,
+    adaptive_dropped_percentage,
+    adaptive_dl_diff_target,
+    adaptive_intensity,
+    available_only_ratio_tally,
+    adaptive_latest_server_time,
+    local_call_time,
+    dial_timeout,
+    dial_statuses 
+FROM 
+    vicidial_campaigns
+
+
+#SACAR EL DIAL LEVEL
+SELECT 
+    AVG(auto_dial_level) + 0.03 AS adjusted_dial_level
+FROM 
+    vicidial_campaigns;
+
+#SACAR EL TRUNK SHORT
+
+select sum(local_trunk_shortage) from vicidial_campaign_server_stats;
+
+SELECT auto_dial_level from vicidial_campaigns;
+
+SELECT AVG(CAST(auto_dial_level AS DECIMAL(10,4))) AS avg_auto_dial_level
+FROM vicidial_campaigns;
+
+
+
+
+SELECT agents_average_onemin, differential_onemin,campaign_id
+FROM vicidial_campaign_stats ;
+
+
+SELECT avg(agents_average_onemin) AS avg_agents
+FROM vicidial_campaign_stats vcs
+INNER JOIN vicidial_live_agents vla
+ON vcs.campaign_id = vla.campaign_id;
+
+SELECT AVG(vcs.agents_average_onemin) AS avg_agents_average_onemin, count(vcs.agents_average_onemin)
+FROM vicidial_campaign_stats vcs
+INNER JOIN vicidial_live_agents vla
+ON vcs.campaign_id = vla.campaign_id;
+
+select DISTINCT(campaign_id), agents_average_onemin FROM vicidial_campaign_stats vcs
+INNER JOIN vicidial_live_agents vla
+ON vcs.campaign_id = vla.campaign_id;
+
+
+
+
+SELECT 
+    AVG(vc.auto_dial_level) AS Dial_LEVEL,
+    (SELECT SUM(vcss.local_trunk_shortage) 
+     FROM vicidial_campaign_server_stats vcss) AS TRUNK_SHORT,
+    (SELECT AVG(balance_trunk_fill) 
+     FROM vicidial_campaign_stats vcs) AS TRUNK_FILL,
+
+    GROUP_CONCAT(DISTINCT vc.lead_filter_id SEPARATOR ', ') AS FILTER,
+    AVG(vc.adaptive_maximum_level) AS MAX_LEVEL,
+    AVG(vc.adaptive_dropped_percentage) AS DROPPED_MAX,
+    AVG(vc.adaptive_dl_diff_target) AS TARGET_DIFF,
+    AVG(vc.adaptive_intensity) AS INTENSITY,
+    AVG(vc.dial_timeout) AS DIAL_TIMEOUT,
+    MAX(vc.adaptive_latest_server_time) AS TAPER_TIME,
+    GROUP_CONCAT(DISTINCT vc.local_call_time SEPARATOR ', ') AS LOCAL_TIME,
+    GROUP_CONCAT(DISTINCT vc.available_only_ratio_tally SEPARATOR ', ') AS AVAIL_ONLY,
+    (SELECT SUM(vcs.dialable_leads) AS DIALABLE_LEADS 
+     FROM vicidial_campaign_stats vcs) AS DIALABLE_LEADS,
+    (SELECT SUM(vcs.calls_today) AS CALLS_TODAY
+     FROM vicidial_campaign_stats vcs) AS CALLS_TODAY, 
+    
+    
+    GROUP_CONCAT(DISTINCT vc.lead_order SEPARATOR ', ') AS ALL_LEAD_ORDERS,
+    GROUP_CONCAT(DISTINCT vc.dial_status_b SEPARATOR ', ') AS all_dial_status_b,
+    GROUP_CONCAT(DISTINCT vc.dial_status_c SEPARATOR ', ') AS all_dial_status_c,
+    GROUP_CONCAT(DISTINCT vc.dial_status_d SEPARATOR ', ') AS all_dial_status_d,
+    GROUP_CONCAT(DISTINCT vc.dial_status_e SEPARATOR ', ') AS all_dial_status_e,
+    AVG(vc.hopper_level) AS avg_hopper_level,
+    GROUP_CONCAT(DISTINCT vc.dial_method SEPARATOR ', ') AS all_dial_methods,
+    GROUP_CONCAT(DISTINCT vc.dial_statuses SEPARATOR ', ') AS all_dial_statuses
+FROM 
+    vicidial_campaigns vc;
+
+
+
+
+
+SELECT 
+    AVG(vc.auto_dial_level) AS Dial_LEVEL,
+    (SELECT SUM(vcss.local_trunk_shortage) 
+     FROM vicidial_campaign_server_stats vcss) AS TRUNK_SHORT,
+    (SELECT AVG(balance_trunk_fill) 
+     FROM vicidial_campaign_stats vcs) AS TRUNK_FILL,
+    GROUP_CONCAT(DISTINCT vc.lead_filter_id SEPARATOR ', ') AS FILTER,
+    AVG(vc.adaptive_maximum_level) AS MAX_LEVEL,
+    AVG(vc.adaptive_dropped_percentage) AS DROPPED_MAX,
+    AVG(vc.adaptive_dl_diff_target) AS TARGET_DIFF,
+    AVG(vc.adaptive_intensity) AS INTENSITY,
+    AVG(vc.dial_timeout) AS DIAL_TIMEOUT,
+    MAX(vc.adaptive_latest_server_time) AS TAPER_TIME,
+    (SELECT local_call_time 
+     FROM vicidial_campaigns 
+     LIMIT 1) AS LOCAL_TIME,
+    GROUP_CONCAT(DISTINCT vc.available_only_ratio_tally SEPARATOR ', ') AS AVAIL_ONLY,
+    (SELECT SUM(vcs.dialable_leads) 
+     FROM vicidial_campaign_stats vcs) AS DIALABLE_LEADS,
+    (SELECT SUM(vcs.calls_today) 
+     FROM vicidial_campaign_stats vcs) AS CALLS_TODAY, 
+    (SELECT AVG(agents_average_onemin) 
+     FROM vicidial_campaign_stats) AS AVG_AGENTS,
+    GROUP_CONCAT(DISTINCT vc.dial_method SEPARATOR ', ') AS DIAL_METHOD,
+    SUM(vc.hopper_level) AS HOPPER,
+    SUM(vc.auto_hopper_level) AS AUTO_HOPPER,
+    (SELECT SUM(drops_today) 
+     FROM vicidial_campaign_stats) AS DROPPED,
+    (SELECT SUM(answers_today) 
+     FROM vicidial_campaign_stats) AS ANSWERED,
+    (SELECT AVG(differential_onemin) 
+     FROM vicidial_campaign_stats) AS AVG_DIFF_ONEMIN,
+    (SELECT vc.dial_statuses 
+     FROM vicidial_campaigns vc 
+     ORDER BY vc.dial_statuses ASC 
+     LIMIT 1) AS STATUSES,
+    (SELECT COUNT(*) 
+     FROM vicidial_hopper) AS LEADS_IN_HOPPER,
+    (SELECT 
+        CASE 
+            WHEN SUM(vcs.drops_answers_today_pct) >= AVG(vc.adaptive_dropped_percentage) 
+                THEN CONCAT(SUM(vcs.drops_answers_today_pct), ' (ALERTA)') 
+            ELSE SUM(vcs.drops_answers_today_pct) 
+        END
+     FROM vicidial_campaign_stats vcs
+     JOIN vicidial_campaigns vc 
+     ON vcs.campaign_id = vc.campaign_id) AS DROPPED_PERCENT
+FROM 
+    vicidial_campaigns vc;
+
+
+
+
+
+
+
+
+
+
+
+
+#CONSULTAR AVG_AGENTS POR CAMPA;A activas
+SELECT AVG(vcs.agents_average_onemin) AS AVG_AGENTS FROM vicidial_campaign_stats vcs INNER JOIN (SELECT DISTINCT campaign_id FROM vicidial_live_agents) vla ON vcs.campaign_id = vla.campaign_id;
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Se refactoriza el codigo sql de la vista real-time-reports para que sea mas legible y se elimina codigo innecesario. Se termino de realizar el query para la primera seccion de la vista real-time-reports solo faltan los iconos que sea el siguiente paso.